### PR TITLE
Better Offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You are invited to reuse this app on your portal project, mostly because it hold
 - this response is usually displayed in an ad-hoc popup/window upon WiFi connection and allow closing/close-itself upon certain condition.
 - the app records (in an SQLite DB) that it has seen this User using it's MAC address and IP address.
 - upon *confirmation* by User, it *registers* him by setting a registration date on the record and request the *filter module* to allow traffic.
-- User's system detects that it it no longer *blocked* and finishes the popup session.
+- Either User's system detects that it it no longer *blocked* (in case the server is connected to Internet) or receives the faked *Expected Success Response* and finishes the popup session.
 
 ## compatibility
 
@@ -65,7 +65,7 @@ Configuration is done solely via environment variables
 
 - **Inactive** clients are devices that stopped making network connections. On modern systems, this usually not happens as most OS phone home frequently (including for captive portal detection!). This is thus mostly used to detect *disconnected* or *sleeping* devices.
 - We do this because we assume devices can be shared by multiple users who might not know our main content URL.
-- App is somewhat flexible regarding the *filter module*. we only use and tested the `portal_filter` one but the default (dummy) one is much useful during portal-UI development.
+- App is somewhat flexible regarding the *filter module*. We only use and tested the `portal_filter` one but the default (dummy) one is much useful during portal-UI development.
 
 ## [dev] i18n updates
 
@@ -144,3 +144,4 @@ Configuration is done solely via environment variables
 | `CAPTURED_NETWORKS`  |               | List of `|` separated networks to limit *capture* to. Otherwise any traffic |
 | `HTTP_PORT`          | `2080`        | Port to redirect captured HTTP traffic to on *HOTSPOT_IP*                   |
 | `HTTPS_PORT`         | `2443`        | Port to redirect captured HTTPS traffic to on *HOTSPOT_IP*                  |
+| `ALWAYS_ONLINE`      |               | Assumes system should be connected to Internet and route traffic            |

--- a/portal/platforms.py
+++ b/portal/platforms.py
@@ -43,12 +43,6 @@ LINUX_HOSTS = ["connectivity-check.ubuntu.com", "nmcheck.gnome.org"]
 FIREFOX_HOSTS = ["detectportal.firefox.com"]
 
 
-def append_headers(response: flask.Response) -> flask.Response:
-    """passed response augmented with common headers"""
-    response.headers["Cache-Control"] = "public,must-revalidate,max-age=0,s-maxage=3600"
-    return response
-
-
 def is_google_request(request):
     return request.path == "/gen_204" or request.path == "/generate_204"
 
@@ -86,11 +80,9 @@ def is_firefox_request(request):
 
 def apple_success(request, user):
     """Fake apple Success page (200 with body containing Success)"""
-    return append_headers(
-        flask.make_response(
+    return flask.make_response(
             "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"
         )
-    )
 
 
 def firefox_success(request, user):
@@ -101,41 +93,41 @@ def firefox_success(request, user):
         200,
     )
     resp.headers["Content-Type"] = "text/html"
-    return append_headers(resp)
+    return resp
 
 
 def microsoft_success(request, user):
     """`Microsoft Connect Test` 200 response"""
     resp = flask.make_response("Microsoft Connect Test", 200)
     resp.headers["Content-Type"] = "text/html"
-    return append_headers(resp)
+    return resp
 
 
 def microsoft_success_ncsi(request, user):
     """`Microsoft NCSI` 200 response"""
     resp = flask.make_response("Microsoft NCSI", 200)
     resp.headers["Content-Type"] = "text/plain"
-    return append_headers(resp)
+    return resp
 
 
 def nmcheck_success(request, user):
     """`NetworkManager is online` 200 response"""
     resp = flask.make_response("NetworkManager is online\n", 200)
     resp.headers["Content-Type"] = "text/plain; charset=UTF-8"
-    return append_headers(resp)
+    return resp
 
 
 def ubuntu_success(request, user):
     """HTTP 1.1/204 No Content with X-NetworkManager-Status header"""
     resp = flask.make_response("", 204)
     resp.headers["X-NetworkManager-Status"] = "online"
-    return append_headers(resp)
+    return resp
 
 
 def no_content(request, user):
     """HTTP 1.1/204 No Content"""
     resp = flask.make_response("", 204)
-    return append_headers(resp)
+    return resp
 
 
 def success(request, user):
@@ -163,4 +155,4 @@ def success(request, user):
 
     # default to regular 204
     logger.debug("is_default")
-    return no_content(request, user)
+    return None


### PR DESCRIPTION
[portal]
- return portal on non-known captive page for registered user this means a request to google.com (/!\ https) on the portal would return the registered success portal page instead of an empty 204 response. very useful when offline to redirect doomed traffic to hotspot
- all portal response to include Cache-Control

[filter]
- added a retry to scapy import as underlying network deps might not be ready on container start in offline scenario
- added `ALWAYS_ONLINE` environ to save checking connectivity when it should always be on
- split behavior for offline and offline: using passlist only when online